### PR TITLE
Update build-avalon-image.sh

### DIFF
--- a/scripts/build-avalon-image.sh
+++ b/scripts/build-avalon-image.sh
@@ -14,8 +14,8 @@ if [ "${HOST_TARGET}" == "brcm2708" ]; then
     OPENWRT_CONFIG=config.${MACHINE}.raspberry-pi
 fi
 
-
-VERSION=20140124
+DATE=`date +%Y%m%d`
+VERSION=${DATE}
 OPENWRT_PATH=./openwrt
 LUCI_PATH=./luci
 


### PR DESCRIPTION
These changes will allow that all subsequent builds will automatically be dated the current date that they are built on so no more having to edit this file to change the date for each and every build
