### PR TITLE
Update build-avalon-image.sh

### DIFF
--- a/scripts/build-avalon-image.sh
+++ b/scripts/build-avalon-image.sh
@@ -41,7 +41,7 @@ Usage: $0 [--version] [--help] [--clone] [--update] [--cgminer]
 Without any parameter I will build the Avalon firmware. make sure you run
   [$0 --clone] ONCE for get all sources
 
-     --clean	Remove all files
+     --removeall	Remove all files
 
 Written by: Xiangfu <xiangfu@openmobilefree.net>
 		    19BT2rcGStUK23vwrmF6y6s3ZWpxzQQn8x
@@ -52,7 +52,7 @@ fi
 
 
 ## Remove
-if [ "$1" == "--clean" ]; then
+if [ "$1" == "--removeall" ]; then
     rm -rf avalon/cgminer avalon/cgminer-openwrt-packages/ avalon/luci/ avalon/openwrt/ 
     exit $?
 fi


### PR DESCRIPTION
These changes will allow for a better understanding of the formally called --clean argument now renamed to --removeall, And the second change will allow that all subsequent builds will automatically be dated the current date that they are built on so no more having to edit this file to change the date for each and every build
