### PR TITLE
Multiple boards support: clone once, build multiple images for different boards

### DIFF
--- a/scripts/aci/aci.sh
+++ b/scripts/aci/aci.sh
@@ -100,9 +100,25 @@ if ! diff $REVISION_NEW $REVISION_LOG > $BUILD_LOG 2>&1; then
 
         TIME_BEGIN=`date +"%Y%m%d %H:%M:%S"`
         BUILD_BEGIN=`date +%s`
-        ./build-avalon-image.sh --clone >> $BUILD_LOG 2>&1 \
-                && ./build-avalon-image.sh >> $BUILD_LOG 2>&1 \
-                && ./build-avalon-image.sh --cgminer >> $BUILD_LOG 2>&1
+        AVA_TARGET_BOARD=tl-wr1043nd-v2 ./build-avalon-image.sh --build >> $BUILD_LOG 2>&1      && \
+                AVA_TARGET_BOARD=tl-wr1043nd-v2 ./build-avalon-image.sh >> $BUILD_LOG 2>&1              && \
+                AVA_TARGET_BOARD=tl-wr1043nd-v2 ./build-avalon-image.sh --cgminer >> $BUILD_LOG 2>&1    && \
+                echo "===========================================================" >> $BUILD_LOG 2>&1   && \
+                echo "=================== tl-wr1043nd-v2 DONE ===================" >> $BUILD_LOG 2>&1   && \
+                echo "===========================================================" >> $BUILD_LOG 2>&1   && \
+                AVA_TARGET_BOARD=tl-wr703n-v1 ./build-avalon-image.sh --build >> $BUILD_LOG 2>&1        && \
+                AVA_TARGET_BOARD=tl-wr703n-v1 ./build-avalon-image.sh >> $BUILD_LOG 2>&1                && \
+                AVA_TARGET_BOARD=tl-wr703n-v1 ./build-avalon-image.sh --cgminer >> $BUILD_LOG 2>&1      && \
+                echo "===========================================================" >> $BUILD_LOG 2>&1   && \
+                echo "==================== tl-wr703n-v1 DONE ====================" >> $BUILD_LOG 2>&1   && \
+                echo "===========================================================" >> $BUILD_LOG 2>&1   && \
+                AVA_TARGET_BOARD=pi-modelb-v2 ./build-avalon-image.sh --build >> $BUILD_LOG 2>&1        && \
+                AVA_TARGET_BOARD=pi-modelb-v2 ./build-avalon-image.sh >> $BUILD_LOG 2>&1                && \
+                AVA_TARGET_BOARD=pi-modelb-v2 ./build-avalon-image.sh --cgminer >> $BUILD_LOG 2>&1      && \
+                echo "===========================================================" >> $BUILD_LOG 2>&1   && \
+                echo "==================== pi-modelb-v2 DONE ====================" >> $BUILD_LOG 2>&1   && \
+                echo "===========================================================" >> $BUILD_LOG 2>&1
+        RET="$?"
         TIME_END=`date +"%Y%m%d %H:%M:%S"`
         BUILD_END=`date +%s`
         BUILD_COST=0
@@ -117,15 +133,25 @@ if ! diff $REVISION_NEW $REVISION_LOG > $BUILD_LOG 2>&1; then
         echo                                                                    >> $BUILD_LOG
         echo "############################################################"     >> $BUILD_LOG
         echo " FROM  ${TIME_BEGIN}  TO  ${TIME_END}"                            >> $BUILD_LOG
+        echo " BUILD RETURN : ${RET}"                                           >> $BUILD_LOG
         echo " TIME COST ${BUILD_H}:${BUILD_M}:${BUILD_S}"                      >> $BUILD_LOG
         echo "############################################################"     >> $BUILD_LOG
         echo                                                                    >> $BUILD_LOG
 
         cd $WORKDIR
         chmod 0755 $WORKDIR/$BUILD_DIR
-        my_mail "Avalon Build End $BUILD_DIR" "`echo --DIFF-- && echo && diff $REVISION_NEW $REVISION_LOG` `echo && echo --NEW-- && cat $REVISION_NEW && echo && echo --OLD-- && cat $REVISION_LOG` `echo && echo --BUILD-- && tail -6 $BUILD_LOG`"
-        mv $REVISION_NEW $REVISION_LOG
+        my_mail "Avalon Build End ${BUILD_DIR}$([ $RET != 0 ] && echo -FAILED-${RET})" \
+                "`echo ============================================================ && echo` \
+                 `echo  FROM  ${TIME_BEGIN}  TO  ${TIME_END} && echo` \
+                 `echo  BUILD RETURN : ${RET} && echo` \
+                 `echo  TIME COST ${BUILD_H}:${BUILD_M}:${BUILD_S} && echo` \
+                 `echo ============================================================ && echo` \
+                 `echo && echo && echo --DIFF-- && diff $REVISION_NEW $REVISION_LOG` \
+                 `echo && echo && echo --NEW-- && cat $REVISION_NEW && echo && echo --OLD-- && cat $REVISION_LOG` \
+                 `echo && echo && echo --ls-- && ls -lR $WORKDIR/$BUILD_DIR/avalon/bin/`"
         rm -rf $WORKDIR/$BUILD_DIR/avalon/[cdlo]* $WORKDIR/$BUILD_DIR/build-avalon-image.sh
+        [ "$RET" != "0" ] && mv $WORKDIR/$BUILD_DIR $WORKDIR/$BUILD_DIR_failed
+        mv $REVISION_NEW $REVISION_LOG
         exit 0
 else
         cd $WORKDIR

--- a/scripts/build-avalon-image.sh
+++ b/scripts/build-avalon-image.sh
@@ -1,26 +1,30 @@
 #!/bin/bash
 
 #MACHINE=avalon
-MACHINE=avalon2	# Support Avalon2/MM firmware
+MACHINE=avalon2                         # Support Avalon2/MM firmware
 
-HOST_TARGET=ar71xx	# TP-LINK WR703N
-#HOST_TARGET=brcm2708	# Raspberry Pi
+#AVA_TARGET_BOARD=tl-wr703n-v1   # TP-Link WR703N-v1
+#AVA_TARGET_BOARD=tl-wr1043nd-v2 # TP-Link WR1043ND-v2
+#AVA_TARGET_BOARD=pi-modelb-v2   # Raspberry-Pi ModelB-v2
+[ -z "${AVA_TARGET_BOARD}" ]  && AVA_TARGET_BOARD=tl-wr703n-v1  # TP-Link WR703N-v1
 
-if [ "${HOST_TARGET}" == "ar71xx" ]; then
-    OPENWRT_CONFIG=config.${MACHINE}.703n
-fi
-
-if [ "${HOST_TARGET}" == "brcm2708" ]; then
-    OPENWRT_CONFIG=config.${MACHINE}.raspberry-pi
-fi
+OPENWRT_CONFIG=""
+[ "${AVA_TARGET_BOARD}" == "tl-wr703n-v1" ] && AVA_TARGET_PLATFORM=ar71xx && OPENWRT_CONFIG=config.${MACHINE}.703n
+[ "${AVA_TARGET_BOARD}" == "tl-wr1043nd-v2" ] && AVA_TARGET_PLATFORM=ar71xx && OPENWRT_CONFIG=config.${MACHINE}.1043nd-v2
+[ "${AVA_TARGET_BOARD}" == "pi-modelb-v2" ] && AVA_TARGET_PLATFORM=brcm2708 && OPENWRT_CONFIG=config.${MACHINE}.raspberry-pi
+[ -z "${OPENWRT_CONFIG}" ] && echo "[ERROR]: Target board not suported" && exit 1
 
 
-VERSION=20140124
+VERSION=20140415
 OPENWRT_PATH=./openwrt
 LUCI_PATH=./luci
 
-CORE_NUM="`nproc`"
-[ "$CORE_NUM" -ge "2" ] || CORE_NUM=2
+# According to http://wiki.openwrt.org/doc/howto/build
+unset SED
+unset GREP_OPTIONS
+[ "`id -u`" == "0" ] && echo "[ERROR]: Please use non-root user" && exit 1
+CORE_NUM="$(expr $(nproc) + 1)"
+[ -z "$CORE_NUM" ] && CORE_NUM=2
 
 ## Version
 if [ "$#" == "0" -a ! -d ./avalon ]; then
@@ -29,33 +33,39 @@ if [ "$#" == "0" -a ! -d ./avalon ]; then
 elif [ "$1" == "--version" ] || [ "$1" == "--help" ]; then
     echo "\
 
-Usage: $0 [--version] [--help] [--clone] [--update] [--cgminer]
+Usage: $0 [--version] [--help] [--clone] [--build] [--update] [--cgminer]
 
      --version
-     --help	Display help message
+     --help             Display help message
 
-     --clone	Get all source code and build firmware, ONLY NEED ONCE
+     --clone            Get all source code, ONLY NEED ONCE
 
-     --update	Update all repos
+     --build            Get .config file and build firmware
 
-     --cgminer	Re-compile only cgminer openwrt package
+     --update           Update all repos
+
+     --cgminer          Re-compile only cgminer openwrt package
 
 Without any parameter I will build the Avalon firmware. make sure you run
   [$0 --clone] ONCE for get all sources
 
-     --removeall	Remove all files
+     --removeall        Remove all files
+
+     AVA_TARGET_BOARD   Environment variable, available target:
+                        tl-wr703n-v1, tl-wr1043nd-v2, pi-modelb-v2
+                        use tl-wr703n-v1 if unset
 
 Written by: Xiangfu <xiangfu@openmobilefree.net>
-		    19BT2rcGStUK23vwrmF6y6s3ZWpxzQQn8x
+                    19BT2rcGStUK23vwrmF6y6s3ZWpxzQQn8x
 
-						     Version: ${VERSION}"
+                                                     Version: ${VERSION}"
     exit 0
 fi
 
 
 ## Remove
 if [ "$1" == "--removeall" ]; then
-    rm -rf avalon/cgminer avalon/cgminer-openwrt-packages/ avalon/luci/ avalon/openwrt/ 
+    rm -rf avalon/cgminer avalon/cgminer-openwrt-packages/ avalon/luci/ avalon/openwrt/
     exit $?
 fi
 
@@ -69,9 +79,9 @@ if [ "$1" == "--clone" ]; then
     git clone git://github.com/BitSyncom/cgminer-openwrt-packages.git
 
     if [ "${MACHINE}" == "avalon2" ]; then
-	git clone git://github.com/BitSyncom/luci.git && (cd luci && git checkout -b cgminer-webui-avalon2 origin/cgminer-webui-avalon2)
+        git clone git://github.com/BitSyncom/luci.git && (cd luci && git checkout -b cgminer-webui-avalon2 origin/cgminer-webui-avalon2)
     else
-	git clone git://github.com/BitSyncom/luci.git && (cd luci && git checkout -b cgminer-webui origin/cgminer-webui)
+        git clone git://github.com/BitSyncom/luci.git && (cd luci && git checkout -b cgminer-webui origin/cgminer-webui)
     fi
      
     cd openwrt
@@ -82,7 +92,17 @@ if [ "$1" == "--clone" ]; then
     ./scripts/feeds update -a && ./scripts/feeds install -a
 
     ln -s feeds/cgminer/cgminer/root-files files
+    exit 0
+fi
 
+if [ "$1" == "--build" ]; then
+    if [ ! -d avalon/openwrt ]; then
+        rm -rf avalon/*
+        "$0" --clone
+        [ "$?" != "0" ] && echo "[ERROR]: clone failed" && exit 1
+    fi
+    cd avalon/openwrt/
+    make clean
     wget https://raw.github.com/BitSyncom/cgminer-openwrt-packages/master/cgminer/data/${OPENWRT_CONFIG} -O .config
     yes "" | make oldconfig
     make -j${CORE_NUM} V=s IGNORE_ERRORS=m || make V=s IGNORE_ERRORS=m
@@ -109,9 +129,10 @@ make -j${CORE_NUM} -C ${OPENWRT_PATH} package/cgminer/{clean,compile} V=s || mak
 RET="$?"
 if [ "${RET}" != "0" ] || [ "$1" == "--cgminer" ]; then
     if [ "${RET}" == "0" ]; then
-	cp ${OPENWRT_PATH}/bin/${HOST_TARGET}/packages/cgminer*.ipk  bin/
-	cp ${OPENWRT_PATH}/build_dir/target-*uClibc-*/cgminer-*/cgminer bin/cgminer-${HOST_TARGET}
-	exit "$?"
+        mkdir -p bin/${AVA_TARGET_BOARD}
+        cp ${OPENWRT_PATH}/bin/${AVA_TARGET_PLATFORM}/packages/cgminer*.ipk  bin/${AVA_TARGET_BOARD}
+        cp ${OPENWRT_PATH}/build_dir/target-*uClibc-*/cgminer-*/cgminer bin/${AVA_TARGET_BOARD}/cgminer-${AVA_TARGET_PLATFORM}
+        exit "$?"
     fi
     exit "${RET}"
 fi
@@ -135,14 +156,14 @@ if [ ! -z "`cd cgminer-openwrt-packages && git status -s -uno`" ]; then
     OW_GIT_STATUS="+"
 fi
 
-rm -rf ${LUCI_PATH}/applications/luci-cgminer/dist                                                && \
-( make -j${CORE_NUM} -C ${LUCI_PATH} || make -C ${LUCI_PATH} )                                    && \
-cp -a  ${LUCI_PATH}/applications/luci-cgminer/dist/* ${OPENWRT_PATH}/files/                       && \
-echo "$DATE"		                              > ${OPENWRT_PATH}/files/etc/avalon_version  && \
-echo "cgminer: $GIT_VERSION$GIT_STATUS"               >> ${OPENWRT_PATH}/files/etc/avalon_version && \
-echo "cgminer-openwrt-packages: $OW_GIT_VERSION$OW_GIT_STATUS" >> ${OPENWRT_PATH}/files/etc/avalon_version && \
-echo "luci: $LUCI_GIT_VERSION$LUCI_GIT_STATUS"        >> ${OPENWRT_PATH}/files/etc/avalon_version && \
-( make -j${CORE_NUM} -C ${OPENWRT_PATH} V=s IGNORE_ERRORS=m || make -C ${OPENWRT_PATH} V=s IGNORE_ERRORS=m ) && \
-mkdir -p bin/${DATE}/                                     && \
-cp -a ${OPENWRT_PATH}/bin/${HOST_TARGET}/*  bin/${DATE}/
+rm -rf ${LUCI_PATH}/applications/luci-cgminer/dist                                                              && \
+( make -j${CORE_NUM} -C ${LUCI_PATH} || make -C ${LUCI_PATH} )                                                  && \
+cp -a  ${LUCI_PATH}/applications/luci-cgminer/dist/* ${OPENWRT_PATH}/files/                                     && \
+echo "$DATE"                                                    >  ${OPENWRT_PATH}/files/etc/avalon_version     && \
+echo "cgminer: $GIT_VERSION$GIT_STATUS"                         >> ${OPENWRT_PATH}/files/etc/avalon_version     && \
+echo "cgminer-openwrt-packages: $OW_GIT_VERSION$OW_GIT_STATUS"  >> ${OPENWRT_PATH}/files/etc/avalon_version     && \
+echo "luci: $LUCI_GIT_VERSION$LUCI_GIT_STATUS"                  >> ${OPENWRT_PATH}/files/etc/avalon_version     && \
+( make -j${CORE_NUM} -C ${OPENWRT_PATH} V=s IGNORE_ERRORS=m || make -C ${OPENWRT_PATH} V=s IGNORE_ERRORS=m )    && \
+mkdir -p bin/${AVA_TARGET_BOARD}/${DATE}/                                                                       && \
+cp -a ${OPENWRT_PATH}/bin/${AVA_TARGET_PLATFORM}/*  bin/${AVA_TARGET_BOARD}/${DATE}/
 


### PR DESCRIPTION
1. split clone to clone and build
   --clone will ONLY get source code
   --build will get .config and build firmware
2. add AVA_TARGET_BOARD environment variable for build different boards
   use TP-Link WR703n-v1 if the variable is unset
   support WR703n-v1, WR1043ND-v2, Raspberry-Pi now
3. more update according to OpenWrt HowTo
4. output path changed, add board-name
5. replace TAB to spaces
6. Update version to 20140415, because of the significant change
