### PR TITLE
OpenWrt should be upgraded

### DIFF
--- a/scripts/aci/feeds-extra.conf
+++ b/scripts/aci/feeds-extra.conf
@@ -1,7 +1,7 @@
 # src-<protocol> <checkout directory>   <url>                                           [branch]
 #
 # Protocols supported: svn, git, git-b
-src-svn         openwrt                 svn://svn.openwrt.org/openwrt/trunk@39381
+src-svn         openwrt                 svn://svn.openwrt.org/openwrt/trunk@41240
 src-git         cgminer0                git://github.com/BitSyncom/cgminer.git
 src-git-b       cgminer-webui-avalon2   git://github.com/BitSyncom/luci.git             origin/cgminer-webui-avalon2
 src-git-b       cgminer-webui           git://github.com/BitSyncom/luci.git             origin/cgminer-webui

--- a/scripts/build-avalon-image.sh
+++ b/scripts/build-avalon-image.sh
@@ -76,7 +76,7 @@ fi
 if [ "$1" == "--clone" ]; then
     [ ! -d avalon ] && mkdir -p avalon/bin
     cd avalon
-    svn co svn://svn.openwrt.org/openwrt/trunk@41224 openwrt
+    svn co svn://svn.openwrt.org/openwrt/trunk@41240 openwrt
     git clone git://github.com/BitSyncom/cgminer.git
     git clone git://github.com/BitSyncom/cgminer-openwrt-packages.git
 


### PR DESCRIPTION
According to "svn log -r 41143 svn://svn.openwrt.org/openwrt/trunk", curl has been moved.
It will cause "missing libcurl" error during build.
So we should use newer version for OpenWrt Trunk.

"procd" of OpenWrt-r41224 also cannot be built (svn log -r 41239 svn://svn.openwrt.org/openwrt/trunk).
That's why I use the newer r41240.
